### PR TITLE
Fix handling of where clauses

### DIFF
--- a/src/derive/box.rs
+++ b/src/derive/box.rs
@@ -45,6 +45,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // a generic type that implements the trait for which we provide the
     // blanket implementation
     let trait_generics = &trait_.generics;
+    let where_clause = &trait_.generics.where_clause;
     let mut impl_generics = trait_generics.clone();
     impl_generics.params.push(syn::GenericParam::Type(
         parse_quote!(#generic_type: #trait_ident #trait_generics),
@@ -53,7 +54,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // generate the impl block
     Ok(parse_quote!(
         #[automatically_derived]
-        impl #impl_generics #trait_ident #trait_generics for Box<#generic_type> {
+        impl #impl_generics #trait_ident #trait_generics for Box<#generic_type> #where_clause {
             #(#methods)*
         }
     ))

--- a/src/derive/mut.rs
+++ b/src/derive/mut.rs
@@ -42,6 +42,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // a generic type that implements the trait for which we provide the
     // blanket implementation
     let trait_generics = &trait_.generics;
+    let where_clause = &trait_.generics.where_clause;
     let mut impl_generics = trait_generics.clone();
     impl_generics.params.push(syn::GenericParam::Type(
         parse_quote!(#generic_type: #trait_ident #trait_generics + ?Sized),
@@ -49,7 +50,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
     Ok(parse_quote!(
         #[automatically_derived]
-        impl #impl_generics #trait_ident #trait_generics for &mut #generic_type {
+        impl #impl_generics #trait_ident #trait_generics for &mut #generic_type #where_clause {
             #(#methods)*
         }
     ))

--- a/src/derive/rc.rs
+++ b/src/derive/rc.rs
@@ -46,6 +46,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // a generic type that implements the trait for which we provide the
     // blanket implementation
     let trait_generics = &trait_.generics;
+    let where_clause = &trait_.generics.where_clause;
     let mut impl_generics = trait_generics.clone();
     impl_generics.params.push(syn::GenericParam::Type(
         parse_quote!(#generic_type: #trait_ident #trait_generics + ?Sized),
@@ -53,7 +54,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
     Ok(parse_quote!(
         #[automatically_derived]
-        impl #impl_generics #trait_ident #trait_generics for std::rc::Rc<#generic_type> {
+        impl #impl_generics #trait_ident #trait_generics for std::rc::Rc<#generic_type> #where_clause {
             #(#methods)*
         }
     ))

--- a/src/derive/ref.rs
+++ b/src/derive/ref.rs
@@ -46,6 +46,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // a generic type that implements the trait for which we provide the
     // blanket implementation
     let trait_generics = &trait_.generics;
+    let where_clause = &trait_.generics.where_clause;
     let mut impl_generics = trait_generics.clone();
     impl_generics.params.push(syn::GenericParam::Type(
         parse_quote!(#generic_type: #trait_ident #trait_generics + ?Sized),
@@ -53,7 +54,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
     Ok(parse_quote!(
         #[automatically_derived]
-        impl #impl_generics #trait_ident #trait_generics for &#generic_type {
+        impl #impl_generics #trait_ident #trait_generics for &#generic_type #where_clause {
             #(#methods)*
         }
     ))

--- a/tests/derive_box/successes/where_clause_assoc_fn.rs
+++ b/tests/derive_box/successes/where_clause_assoc_fn.rs
@@ -1,0 +1,36 @@
+extern crate blanket;
+extern crate impls;
+
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Box))]
+pub trait Counter<T>
+where
+    T: Clone,
+{
+    fn increment(&self, t: T);
+
+    fn super_helpful_helper(&self, t: T)
+    {
+        self.increment(t.clone())
+    }
+}
+
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter<u8> for AtomicCounter {
+    fn increment(&self, value: u8) {
+        self.count.fetch_add(value, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter<u8>));
+    assert!(impls!(Box<AtomicCounter>: Counter<u8>));
+}

--- a/tests/derive_mut/successes/where_clause_assoc_fn.rs
+++ b/tests/derive_mut/successes/where_clause_assoc_fn.rs
@@ -1,0 +1,36 @@
+extern crate blanket;
+extern crate impls;
+
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Mut))]
+pub trait Counter<T>
+where
+    T: Clone,
+{
+    fn increment(&self, t: T);
+
+    fn super_helpful_helper(&self, t: T)
+    {
+        self.increment(t.clone())
+    }
+}
+
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter<u8> for AtomicCounter {
+    fn increment(&self, value: u8) {
+        self.count.fetch_add(value, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter<u8>));
+    assert!(impls!(&mut AtomicCounter: Counter<u8>));
+}

--- a/tests/derive_rc/successes/where_clause_assoc_fn.rs
+++ b/tests/derive_rc/successes/where_clause_assoc_fn.rs
@@ -1,0 +1,37 @@
+extern crate blanket;
+extern crate impls;
+
+use std::rc::Rc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Rc))]
+pub trait Counter<T>
+where
+    T: Clone,
+{
+    fn increment(&self, t: T);
+
+    fn super_helpful_helper(&self, t: T)
+    {
+        self.increment(t.clone())
+    }
+}
+
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter<u8> for AtomicCounter {
+    fn increment(&self, value: u8) {
+        self.count.fetch_add(value, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:     Counter<u8>));
+    assert!(impls!(Rc<AtomicCounter>: Counter<u8>));
+}

--- a/tests/derive_ref/successes/where_clause_assoc_fn.rs
+++ b/tests/derive_ref/successes/where_clause_assoc_fn.rs
@@ -1,0 +1,36 @@
+extern crate blanket;
+extern crate impls;
+
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Ref))]
+pub trait Counter<T>
+where
+    T: Clone,
+{
+    fn increment(&self, t: T);
+
+    fn super_helpful_helper(&self, t: T)
+    {
+        self.increment(t.clone())
+    }
+}
+
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter<u8> for AtomicCounter {
+    fn increment(&self, value: u8) {
+        self.count.fetch_add(value, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:  Counter<u8>));
+    assert!(impls!(&AtomicCounter: Counter<u8>));
+}


### PR DESCRIPTION
I noticed that where clauses from the original trait were missing in the derived impls. This can lead to compile errors if default impls within the trait rely on those constraints. I added the required code to the derive macros as well as test cases for it.

The error in the CI seems to be a result of a chanced rustc error message on the nightly toolchain.