### PR TITLE
Add implementation for #[blanket(derive(Arc))] with associated tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ name = "derive_mut"
 path = "tests/derive_mut/mod.rs"
 harness = false
 [[test]]
+name = "derive_arc"
+path = "tests/derive_arc/mod.rs"
+harness = false
+[[test]]
 name = "derive_rc"
 path = "tests/derive_rc/mod.rs"
 harness = false

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following derives are available:
 |--------|--------------------------------------------|--------------|------------------|-------------|
 | Ref    | `impl<T: Trait + ?Sized> Trait for &T`     | ✔️            |                  |             |
 | Rc     | `impl<T: Trait + ?Sized> Trait for Rc<T>`  | ✔️            |                  |             |
+| Arc    | `impl<T: Trait + ?Sized> Trait for Arc<T>` | ✔️            |                  |             |
 | Mut    | `impl<T: Trait + ?Sized> Trait for &mut T` | ✔️            | ✔️                |             |
 | Box    | `impl<T: Trait> Trait for Box<T>`          | ✔️            | ✔️                | ✔️           |
 
@@ -142,8 +143,8 @@ trait Visitor {
 - ✓ `#[derive(Mut)]`
 - ✓ `#[derive(Box)]`
 - ✓ `#[derive(Rc)]`
+- ✓ `#[derive(Arc)]`
 - ✗ Update `Box` derive to allow unsized types if possible.
-- ✗ `#[derive(Arc)]`
 - ✗ `#[derive(Cow)]`
 
 ## 📋 Changelog

--- a/src/default.rs
+++ b/src/default.rs
@@ -1,7 +1,6 @@
 use syn::spanned::Spanned;
 
-use super::utils::prepend_function_path;
-use super::utils::signature_to_function_call;
+use super::utils::{prepend_function_path, signature_to_function_call};
 
 /// Update the method declarations of `trait_` to use default implementation from `default` module.
 pub fn defer_trait_methods(

--- a/src/derive/arc.rs
+++ b/src/derive/arc.rs
@@ -1,0 +1,191 @@
+use syn::parse_quote;
+use syn::spanned::Spanned;
+
+use crate::utils::deref_expr;
+use crate::utils::generics_declaration_to_generics;
+use crate::utils::signature_to_method_call;
+use crate::utils::trait_to_generic_ident;
+
+pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
+    // build the methods
+    let mut methods: Vec<syn::ImplItemMethod> = Vec::new();
+    for item in trait_.items.iter() {
+        if let syn::TraitItem::Method(ref m) = item {
+            if let Some(receiver) = m.sig.receiver() {
+                match receiver {
+                    syn::FnArg::Receiver(r) if r.mutability.is_some() => {
+                        let msg = "cannot derive `Arc` for a trait declaring `&mut self` methods";
+                        return Err(syn::Error::new(r.span(), msg));
+                    }
+                    syn::FnArg::Receiver(r) if r.reference.is_none() => {
+                        let msg = "cannot derive `Arc` for a trait declaring `self` methods";
+                        return Err(syn::Error::new(r.span(), msg));
+                    }
+                    syn::FnArg::Typed(pat) => {
+                        let msg = "cannot derive `Arc` for a trait declaring methods with arbitrary receiver types";
+                        return Err(syn::Error::new(pat.span(), msg));
+                    }
+                    _ => (),
+                }
+            }
+
+            let mut call = signature_to_method_call(&m.sig)?;
+            call.receiver = Box::new(deref_expr(deref_expr(*call.receiver)));
+
+            let signature = &m.sig;
+            let item = parse_quote!(#[inline] #signature { #call });
+            methods.push(item)
+        }
+    }
+
+    // build an identifier for the generic type used for the implementation
+    let trait_ident = &trait_.ident;
+    let generic_type = trait_to_generic_ident(&trait_);
+
+    // build the generics for the impl block:
+    // we use the same generics as the trait itself, plus
+    // a generic type that implements the trait for which we provide the
+    // blanket implementation
+    let trait_generics = &trait_.generics;
+    let where_clause = &trait_.generics.where_clause;
+    let mut impl_generics = trait_generics.clone();
+
+    // we must however remove the generic type bounds, to avoid repeating them
+    let mut trait_generic_names = trait_generics.clone();
+    trait_generic_names.params = generics_declaration_to_generics(&trait_generics.params)?;
+
+    impl_generics.params.push(syn::GenericParam::Type(
+        parse_quote!(#generic_type: #trait_ident #trait_generic_names + ?Sized),
+    ));
+
+    Ok(parse_quote!(
+        #[automatically_derived]
+        impl #impl_generics #trait_ident #trait_generic_names for std::sync::Arc<#generic_type> #where_clause {
+            #(#methods)*
+        }
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    mod derive {
+
+        use syn::parse_quote;
+
+        #[test]
+        fn empty() {
+            let trait_ = parse_quote!(
+                trait Trait {}
+            );
+            assert_eq!(
+                super::super::derive(&trait_).unwrap(),
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<T: Trait + ?Sized> Trait for std::sync::Arc<T> {}
+                )
+            );
+        }
+
+        #[test]
+        fn receiver_ref() {
+            let trait_ = parse_quote!(
+                trait Trait {
+                    fn my_method(&self);
+                }
+            );
+            assert_eq!(
+                super::super::derive(&trait_).unwrap(),
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<T: Trait + ?Sized> Trait for std::sync::Arc<T> {
+                        #[inline]
+                        fn my_method(&self) {
+                            (*(*self)).my_method()
+                        }
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn receiver_mut() {
+            let trait_ = parse_quote!(
+                trait Trait {
+                    fn my_method(&mut self);
+                }
+            );
+            assert!(super::super::derive(&trait_).is_err());
+        }
+
+        #[test]
+        fn receiver_self() {
+            let trait_ = parse_quote!(
+                trait Trait {
+                    fn my_method(self);
+                }
+            );
+            assert!(super::super::derive(&trait_).is_err());
+        }
+
+        #[test]
+        fn receiver_arbitrary() {
+            let trait_ = parse_quote!(
+                trait Trait {
+                    fn my_method(self: Box<Self>);
+                }
+            );
+            assert!(super::super::derive(&trait_).is_err());
+        }
+
+        #[test]
+        fn generics() {
+            let trait_ = parse_quote!(
+                trait MyTrait<T> {}
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<T, MT: MyTrait<T> + ?Sized> MyTrait<T> for std::sync::Arc<MT> {}
+                )
+            );
+        }
+
+        #[test]
+        fn generics_bounded() {
+            let trait_ = parse_quote!(
+                trait MyTrait<T: 'static + Send> {}
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<T: 'static + Send, MT: MyTrait<T> + ?Sized> MyTrait<T> for std::sync::Arc<MT> {}
+                )
+            );
+        }
+
+        #[test]
+        fn generics_lifetime() {
+            let trait_ = parse_quote!(
+                trait MyTrait<'a, 'b: 'a, T: 'static + Send> {}
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<'a, 'b: 'a, T: 'static + Send, MT: MyTrait<'a, 'b, T> + ?Sized>
+                        MyTrait<'a, 'b, T> for std::sync::Arc<MT>
+                    {
+                    }
+                )
+            );
+        }
+    }
+}

--- a/src/derive/box.rs
+++ b/src/derive/box.rs
@@ -1,10 +1,8 @@
-use syn::parse_quote;
-use syn::spanned::Spanned;
+use syn::{parse_quote, spanned::Spanned};
 
-use crate::utils::deref_expr;
-use crate::utils::generics_declaration_to_generics;
-use crate::utils::signature_to_method_call;
-use crate::utils::trait_to_generic_ident;
+use crate::utils::{
+    deref_expr, generics_declaration_to_generics, signature_to_method_call, trait_to_generic_ident,
+};
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // build the methods

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -1,3 +1,4 @@
+mod arc;
 mod r#box;
 mod r#mut;
 mod rc;
@@ -9,6 +10,7 @@ pub enum Derive {
     Ref,
     Mut,
     Rc,
+    Arc,
 }
 
 impl Derive {
@@ -18,6 +20,7 @@ impl Derive {
             "Ref" => Some(Derive::Ref),
             "Mut" => Some(Derive::Mut),
             "Rc" => Some(Derive::Rc),
+            "Arc" => Some(Derive::Arc),
             _ => None,
         }
     }
@@ -34,6 +37,7 @@ impl Derive {
             Derive::Ref => self::r#ref::derive(trait_),
             Derive::Mut => self::r#mut::derive(trait_),
             Derive::Rc => self::rc::derive(trait_),
+            Derive::Arc => self::arc::derive(trait_),
         }
     }
 }

--- a/src/derive/mut.rs
+++ b/src/derive/mut.rs
@@ -1,10 +1,8 @@
-use syn::parse_quote;
-use syn::spanned::Spanned;
+use syn::{parse_quote, spanned::Spanned};
 
-use crate::utils::deref_expr;
-use crate::utils::generics_declaration_to_generics;
-use crate::utils::signature_to_method_call;
-use crate::utils::trait_to_generic_ident;
+use crate::utils::{
+    deref_expr, generics_declaration_to_generics, signature_to_method_call, trait_to_generic_ident,
+};
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // build the methods

--- a/src/derive/rc.rs
+++ b/src/derive/rc.rs
@@ -1,10 +1,8 @@
-use syn::parse_quote;
-use syn::spanned::Spanned;
+use syn::{parse_quote, spanned::Spanned};
 
-use crate::utils::deref_expr;
-use crate::utils::generics_declaration_to_generics;
-use crate::utils::signature_to_method_call;
-use crate::utils::trait_to_generic_ident;
+use crate::utils::{
+    deref_expr, generics_declaration_to_generics, signature_to_method_call, trait_to_generic_ident,
+};
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // build the methods

--- a/src/derive/ref.rs
+++ b/src/derive/ref.rs
@@ -1,10 +1,8 @@
-use syn::parse_quote;
-use syn::spanned::Spanned;
+use syn::{parse_quote, spanned::Spanned};
 
-use crate::utils::deref_expr;
-use crate::utils::generics_declaration_to_generics;
-use crate::utils::signature_to_method_call;
-use crate::utils::trait_to_generic_ident;
+use crate::utils::{
+    deref_expr, generics_declaration_to_generics, signature_to_method_call, trait_to_generic_ident,
+};
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     // build the methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,8 @@ extern crate quote;
 
 use std::collections::HashSet;
 
-use quote::quote;
-use quote::ToTokens;
-use syn::parse_macro_input;
-use syn::spanned::Spanned;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, spanned::Spanned};
 
 // ---------------------------------------------------------------------------
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,5 @@
 use quote::quote_spanned;
-use syn::parse_quote;
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::GenericParam;
-use syn::Token;
+use syn::{parse_quote, punctuated::Punctuated, spanned::Spanned, GenericParam, Token};
 
 /// Convert a function signature to a function call with the same arguments.
 pub fn signature_to_function_call(sig: &syn::Signature) -> syn::Result<syn::ExprCall> {

--- a/tests/char_visitor.rs
+++ b/tests/char_visitor.rs
@@ -54,6 +54,7 @@ fn test_overload() {
             self.bytes += s.as_bytes().len();
             self::visitor::visit_str(self, s);
         }
+
         fn visit_char(&mut self, c: char) {
             self.count += 1
         }

--- a/tests/derive_arc/fails/noderive.rs
+++ b/tests/derive_arc/fails/noderive.rs
@@ -1,0 +1,29 @@
+extern crate impls;
+extern crate static_assertions;
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use impls::impls;
+use static_assertions::const_assert;
+
+pub trait Counter {
+    fn increment(&self);
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8
+}
+
+impl Counter for AtomicCounter {
+    fn increment(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    const_assert!(impls!(AtomicCounter:       Counter));
+    const_assert!(impls!(Arc<AtomicCounter>:  Counter));
+}

--- a/tests/derive_arc/fails/noderive.stderr
+++ b/tests/derive_arc/fails/noderive.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/noderive.rs:28:5
+   |
+28 |     const_assert!(impls!(Arc<AtomicCounter>:  Counter));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_arc/fails/receiver_box.rs
+++ b/tests/derive_arc/fails/receiver_box.rs
@@ -1,0 +1,10 @@
+extern crate blanket;
+
+use blanket::blanket;
+
+#[blanket(derive(Arc))]
+pub trait Counter {
+    fn increment(self: Box<Self>);
+}
+
+fn main() {}

--- a/tests/derive_arc/fails/receiver_box.stderr
+++ b/tests/derive_arc/fails/receiver_box.stderr
@@ -1,0 +1,5 @@
+error: cannot derive `Arc` for a trait declaring methods with arbitrary receiver types
+ --> $DIR/receiver_box.rs:7:18
+  |
+7 |     fn increment(self: Box<Self>);
+  |                  ^^^^

--- a/tests/derive_arc/fails/receiver_mut.rs
+++ b/tests/derive_arc/fails/receiver_mut.rs
@@ -1,0 +1,10 @@
+extern crate blanket;
+
+use blanket::blanket;
+
+#[blanket(derive(Arc))]
+pub trait Counter {
+    fn increment(&mut self);
+}
+
+fn main() {}

--- a/tests/derive_arc/fails/receiver_mut.stderr
+++ b/tests/derive_arc/fails/receiver_mut.stderr
@@ -1,0 +1,5 @@
+error: cannot derive `Arc` for a trait declaring `&mut self` methods
+ --> $DIR/receiver_mut.rs:7:18
+  |
+7 |     fn increment(&mut self);
+  |                  ^

--- a/tests/derive_arc/fails/receiver_self.rs
+++ b/tests/derive_arc/fails/receiver_self.rs
@@ -1,0 +1,10 @@
+extern crate blanket;
+
+use blanket::blanket;
+
+#[blanket(derive(Arc))]
+pub trait Extract {
+    fn extract(self);
+}
+
+fn main() {}

--- a/tests/derive_arc/fails/receiver_self.stderr
+++ b/tests/derive_arc/fails/receiver_self.stderr
@@ -1,0 +1,5 @@
+error: cannot derive `Arc` for a trait declaring `self` methods
+ --> $DIR/receiver_self.rs:7:16
+  |
+7 |     fn extract(self);
+  |                ^^^^

--- a/tests/derive_arc/mod.rs
+++ b/tests/derive_arc/mod.rs
@@ -1,0 +1,8 @@
+extern crate trybuild;
+
+fn main() {
+    #[cfg(not(tarpaulin))]
+    let t = trybuild::TestCases::new();
+    t.compile_fail(file!().replace("mod.rs", "fails/*.rs"));
+    t.pass(file!().replace("mod.rs", "successes/*.rs"));
+}

--- a/tests/derive_arc/successes/receiver_ref.rs
+++ b/tests/derive_arc/successes/receiver_ref.rs
@@ -1,0 +1,30 @@
+extern crate blanket;
+extern crate impls;
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Arc))]
+pub trait Counter {
+    fn increment(&self);
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter for AtomicCounter {
+    fn increment(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter));
+    assert!(impls!(Arc<AtomicCounter>: Counter));
+}

--- a/tests/derive_arc/successes/trait_generics.rs
+++ b/tests/derive_arc/successes/trait_generics.rs
@@ -1,0 +1,30 @@
+extern crate blanket;
+extern crate impls;
+
+use std::sync::Arc;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Arc))]
+pub trait AsRef2<T> {
+    fn as_ref2(&self) -> &T;
+}
+
+#[derive(Default)]
+struct Owner<T> {
+    owned: T,
+}
+
+impl<T> AsRef2<T> for Owner<T> {
+    fn as_ref2(&self) -> &T {
+        &self.owned
+    }
+}
+
+fn main() {
+    assert!(impls!(Owner<String>:      AsRef2<String>));
+    assert!(impls!(Arc<Owner<String>>: AsRef2<String>));
+    assert!(impls!(Owner<bool>:        AsRef2<bool>));
+    assert!(impls!(Arc<Owner<bool>>:   AsRef2<bool>));
+}

--- a/tests/derive_arc/successes/where_clause_assoc_fn.rs
+++ b/tests/derive_arc/successes/where_clause_assoc_fn.rs
@@ -1,0 +1,37 @@
+extern crate blanket;
+extern crate impls;
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Arc))]
+pub trait Counter<T>
+where
+    T: Clone,
+{
+    fn increment(&self, t: T);
+
+    fn super_helpful_helper(&self, t: T)
+    {
+        self.increment(t.clone())
+    }
+}
+
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter<u8> for AtomicCounter {
+    fn increment(&self, value: u8) {
+        self.count.fetch_add(value, Ordering::SeqCst);
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter<u8>));
+    assert!(impls!(Arc<AtomicCounter>: Counter<u8>));
+}

--- a/tests/derive_box/fails/noderive.stderr
+++ b/tests/derive_box/fails/noderive.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/noderive.rs:21:5
    |
 21 |     const_assert!(impls!(Box<AtomicCounter>: Counter));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_mut/fails/noderive.stderr
+++ b/tests/derive_mut/fails/noderive.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/noderive.rs:21:5
    |
 21 |     const_assert!(impls!(&mut AtomicCounter: Counter));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_mut/fails/receiver_box.stderr
+++ b/tests/derive_mut/fails/receiver_box.stderr
@@ -2,4 +2,4 @@ error: cannot derive `Mut` for a trait declaring methods with arbitrary receiver
  --> $DIR/receiver_box.rs:7:18
   |
 7 |     fn increment(self: Box<Self>);
-  |                  ^^^^^^^^^^^^^^^
+  |                  ^^^^

--- a/tests/derive_rc/fails/noderive.stderr
+++ b/tests/derive_rc/fails/noderive.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/noderive.rs:28:5
    |
 28 |     const_assert!(impls!(Rc<AtomicCounter>:  Counter));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_rc/fails/receiver_box.stderr
+++ b/tests/derive_rc/fails/receiver_box.stderr
@@ -2,4 +2,4 @@ error: cannot derive `Rc` for a trait declaring methods with arbitrary receiver 
  --> $DIR/receiver_box.rs:7:18
   |
 7 |     fn increment(self: Box<Self>);
-  |                  ^^^^^^^^^^^^^^^
+  |                  ^^^^

--- a/tests/derive_rc/fails/receiver_mut.stderr
+++ b/tests/derive_rc/fails/receiver_mut.stderr
@@ -2,4 +2,4 @@ error: cannot derive `Rc` for a trait declaring `&mut self` methods
  --> $DIR/receiver_mut.rs:7:18
   |
 7 |     fn increment(&mut self);
-  |                  ^^^^^^^^^
+  |                  ^

--- a/tests/derive_ref/fails/noderive.stderr
+++ b/tests/derive_ref/fails/noderive.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/noderive.rs:27:5
    |
 27 |     const_assert!(impls!(&AtomicCounter:     Counter));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize` which would overflow
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_ref/fails/receiver_box.stderr
+++ b/tests/derive_ref/fails/receiver_box.stderr
@@ -2,4 +2,4 @@ error: cannot derive `Ref` for a trait declaring methods with arbitrary receiver
  --> $DIR/receiver_box.rs:7:18
   |
 7 |     fn increment(self: Box<Self>);
-  |                  ^^^^^^^^^^^^^^^
+  |                  ^^^^

--- a/tests/derive_ref/fails/receiver_mut.stderr
+++ b/tests/derive_ref/fails/receiver_mut.stderr
@@ -2,4 +2,4 @@ error: cannot derive `Ref` for a trait declaring `&mut self` methods
  --> $DIR/receiver_mut.rs:7:18
   |
 7 |     fn increment(&mut self);
-  |                  ^^^^^^^^^
+  |                  ^

--- a/tests/fails/default-with-default.stderr
+++ b/tests/fails/default-with-default.stderr
@@ -2,4 +2,4 @@ error: method should not have default implementation if using #[blanket(default 
  --> $DIR/default-with-default.rs:6:5
   |
 6 |     fn method() {}
-  |     ^^^^^^^^^^^^^^
+  |     ^^


### PR DESCRIPTION
This implements derive(Arc).

I hope I didn't miss anything, but it works on my crate and all tests are passing.

NOTE: rebased on #3. You probably want to merge that first.