### PR TITLE
Allow crate to compile without leaking features from dev-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "blanket"
 version = "0.1.5"
 authors = ["Martin Larralde <martin.larralde@embl.de>"]
 edition = "2018"
+resolver = "2"
 license = "MIT"
 description = "A simple macro to derive blanket implementations for your traits."
 repository = "https://github.com/althonos/blanket"
@@ -33,7 +34,7 @@ proc-macro2 = "1.0"
 [dependencies.syn]
 version = "1.0"
 default-features = false
-features = ["full"]
+features = ["clone-impls", "full", "parsing", "printing", "proc-macro"]
 
 [dev-dependencies]
 trybuild = "1.0"


### PR DESCRIPTION
When adding blanket as a dependency to a blank cargo project, it fails to
compile. This is due to missing features on the syn crate.

This commit adds the needed features. This problem could not be detected
from within the crate itself because features were leaking through from
the dev-dependency of syn which does not have `default-features = false`.

I turned on `resolver = "2"`. This is the new feature resolver for cargo
that will become the default in edition 2021. This is not strictly necessary
but it helps as it no longer leaks features. This means that `cargo check`
will now fail if there are missing features. As `cargo test` obviously turns
on the features from `dev-dependencies`, this will still not detect the
issue.

You might want to check your CI script and add a `cargo check` before
running `cargo test`.

NOTE: rebased on #3 and #4, so you probably want to merge them first.