### PR TITLE
Implement Associated Types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "blanket"
 version = "0.1.5"
 authors = ["Martin Larralde <martin.larralde@embl.de>"]
 edition = "2018"
+resolver = "2"
 license = "MIT"
 description = "A simple macro to derive blanket implementations for your traits."
 repository = "https://github.com/althonos/blanket"
@@ -33,7 +34,7 @@ proc-macro2 = "1.0"
 [dependencies.syn]
 version = "1.0"
 default-features = false
-features = ["full"]
+features = ["clone-impls", "full", "parsing", "printing", "proc-macro"]
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/src/derive/arc.rs
+++ b/src/derive/arc.rs
@@ -44,12 +44,11 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let attrs   = &t.attrs;
+            let attrs = &t.attrs;
             let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
     }
-
 
     // build the generics for the impl block:
     // we use the same generics as the trait itself, plus
@@ -201,7 +200,9 @@ mod tests {
         #[test]
         fn associated_types() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return; }
+                trait MyTrait {
+                    type Return;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -209,7 +210,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -217,7 +220,9 @@ mod tests {
         #[test]
         fn associated_types_bound() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return: Clone; }
+                trait MyTrait {
+                    type Return: Clone;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -225,7 +230,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -233,7 +240,9 @@ mod tests {
         #[test]
         fn associated_types_dodgy_name() {
             let trait_ = parse_quote!(
-                trait MyTrait { type r#type; }
+                trait MyTrait {
+                    type r#type;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -241,7 +250,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type r#type = <MT as MyTrait>::r#type; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> {
+                        type r#type = <MT as MyTrait>::r#type;
+                    }
                 )
             );
         }
@@ -249,12 +260,12 @@ mod tests {
         #[test]
         fn associated_types_attrs() {
             let trait_ = parse_quote!(
-                trait MyTrait
-                {
-                    #[cfg(target_arch="wasm32")]
+                trait MyTrait {
+                    #[cfg(target_arch = "wasm32")]
                     type Return;
-                    #[cfg(not(target_arch="wasm32"))]
-                    type Return: Send;                }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    type Return: Send;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -262,11 +273,10 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT>
-                    {
-                        #[cfg(target_arch="wasm32")]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> {
+                        #[cfg(target_arch = "wasm32")]
                         type Return = <MT as MyTrait>::Return;
-                        #[cfg(not(target_arch="wasm32"))]
+                        #[cfg(not(target_arch = "wasm32"))]
                         type Return = <MT as MyTrait>::Return;
                     }
                 )

--- a/src/derive/arc.rs
+++ b/src/derive/arc.rs
@@ -44,7 +44,8 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            let attrs   = &t.attrs;
+            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
     }
@@ -241,6 +242,33 @@ mod tests {
                 parse_quote!(
                     #[automatically_derived]
                     impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type r#type = <MT as MyTrait>::r#type; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_attrs() {
+            let trait_ = parse_quote!(
+                trait MyTrait
+                {
+                    #[cfg(target_arch="wasm32")]
+                    type Return;
+                    #[cfg(not(target_arch="wasm32"))]
+                    type Return: Send;                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT>
+                    {
+                        #[cfg(target_arch="wasm32")]
+                        type Return = <MT as MyTrait>::Return;
+                        #[cfg(not(target_arch="wasm32"))]
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }

--- a/src/derive/arc.rs
+++ b/src/derive/arc.rs
@@ -7,8 +7,13 @@ use crate::utils::signature_to_method_call;
 use crate::utils::trait_to_generic_ident;
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
-    // build the methods
+    // build an identifier for the generic type used for the implementation
+    let trait_ident = &trait_.ident;
+    let generic_type = trait_to_generic_ident(&trait_);
+
+    // build the methods & associated types.
     let mut methods: Vec<syn::ImplItemMethod> = Vec::new();
+    let mut assoc_types: Vec<syn::ImplItemType> = Vec::new();
     for item in trait_.items.iter() {
         if let syn::TraitItem::Method(ref m) = item {
             if let Some(receiver) = m.sig.receiver() {
@@ -36,11 +41,14 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
             let item = parse_quote!(#[inline] #signature { #call });
             methods.push(item)
         }
+
+        if let syn::TraitItem::Type(t) = item {
+            let t_ident = &t.ident;
+            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            assoc_types.push(item);
+        }
     }
 
-    // build an identifier for the generic type used for the implementation
-    let trait_ident = &trait_.ident;
-    let generic_type = trait_to_generic_ident(&trait_);
 
     // build the generics for the impl block:
     // we use the same generics as the trait itself, plus
@@ -61,6 +69,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     Ok(parse_quote!(
         #[automatically_derived]
         impl #impl_generics #trait_ident #trait_generic_names for std::sync::Arc<#generic_type> #where_clause {
+            #(#assoc_types)*
             #(#methods)*
         }
     ))
@@ -184,6 +193,54 @@ mod tests {
                         MyTrait<'a, 'b, T> for std::sync::Arc<MT>
                     {
                     }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_bound() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return: Clone; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_dodgy_name() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type r#type; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::sync::Arc<MT> { type r#type = <MT as MyTrait>::r#type; }
                 )
             );
         }

--- a/src/derive/box.rs
+++ b/src/derive/box.rs
@@ -42,7 +42,8 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            let attrs   = &t.attrs;
+            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
     }
@@ -260,6 +261,33 @@ mod tests {
                 parse_quote!(
                     #[automatically_derived]
                     impl<MT: MyTrait> MyTrait for Box<MT> { type r#type = <MT as MyTrait>::r#type; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_attrs() {
+            let trait_ = parse_quote!(
+                trait MyTrait
+                {
+                    #[cfg(target_arch="wasm32")]
+                    type Return;
+                    #[cfg(not(target_arch="wasm32"))]
+                    type Return: Send;                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT>
+                    {
+                        #[cfg(target_arch="wasm32")]
+                        type Return = <MT as MyTrait>::Return;
+                        #[cfg(not(target_arch="wasm32"))]
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }

--- a/src/derive/box.rs
+++ b/src/derive/box.rs
@@ -5,7 +5,6 @@ use crate::utils::{
 };
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
-
     // build an identifier for the generic type used for the implementation
     let trait_ident = &trait_.ident;
     let generic_type = trait_to_generic_ident(&trait_);
@@ -42,12 +41,11 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let attrs   = &t.attrs;
+            let attrs = &t.attrs;
             let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
     }
-
 
     // build the generics for the impl block:
     // we use the same generics as the trait itself, plus
@@ -220,7 +218,9 @@ mod tests {
         #[test]
         fn associated_types() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return; }
+                trait MyTrait {
+                    type Return;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -228,7 +228,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait> MyTrait for Box<MT> { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -236,7 +238,9 @@ mod tests {
         #[test]
         fn associated_types_bound() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return: Clone; }
+                trait MyTrait {
+                    type Return: Clone;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -244,7 +248,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait> MyTrait for Box<MT> { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -252,7 +258,9 @@ mod tests {
         #[test]
         fn associated_types_dodgy_name() {
             let trait_ = parse_quote!(
-                trait MyTrait { type r#type; }
+                trait MyTrait {
+                    type r#type;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -260,7 +268,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait> MyTrait for Box<MT> { type r#type = <MT as MyTrait>::r#type; }
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        type r#type = <MT as MyTrait>::r#type;
+                    }
                 )
             );
         }
@@ -268,12 +278,12 @@ mod tests {
         #[test]
         fn associated_types_attrs() {
             let trait_ = parse_quote!(
-                trait MyTrait
-                {
-                    #[cfg(target_arch="wasm32")]
+                trait MyTrait {
+                    #[cfg(target_arch = "wasm32")]
                     type Return;
-                    #[cfg(not(target_arch="wasm32"))]
-                    type Return: Send;                }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    type Return: Send;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -281,11 +291,10 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait> MyTrait for Box<MT>
-                    {
-                        #[cfg(target_arch="wasm32")]
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        #[cfg(target_arch = "wasm32")]
                         type Return = <MT as MyTrait>::Return;
-                        #[cfg(not(target_arch="wasm32"))]
+                        #[cfg(not(target_arch = "wasm32"))]
                         type Return = <MT as MyTrait>::Return;
                     }
                 )

--- a/src/derive/box.rs
+++ b/src/derive/box.rs
@@ -5,8 +5,14 @@ use crate::utils::{
 };
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
+
+    // build an identifier for the generic type used for the implementation
+    let trait_ident = &trait_.ident;
+    let generic_type = trait_to_generic_ident(&trait_);
+
     // build the methods
     let mut methods: Vec<syn::ImplItemMethod> = Vec::new();
+    let mut assoc_types: Vec<syn::ImplItemType> = Vec::new();
     for item in trait_.items.iter() {
         if let syn::TraitItem::Method(ref m) = item {
             let signature = &m.sig;
@@ -33,11 +39,14 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
             let item = parse_quote!(#[inline] #signature { #call });
             methods.push(item)
         }
+
+        if let syn::TraitItem::Type(t) = item {
+            let t_ident = &t.ident;
+            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            assoc_types.push(item);
+        }
     }
 
-    // build an identifier for the generic type used for the implementation
-    let trait_ident = &trait_.ident;
-    let generic_type = trait_to_generic_ident(&trait_);
 
     // build the generics for the impl block:
     // we use the same generics as the trait itself, plus
@@ -59,6 +68,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     Ok(parse_quote!(
         #[automatically_derived]
         impl #impl_generics #trait_ident #trait_generic_names for Box<#generic_type> #where_clause {
+            #(#assoc_types)*
             #(#methods)*
         }
     ))
@@ -202,6 +212,54 @@ mod tests {
                 parse_quote!(
                     #[automatically_derived]
                     impl<'a, 'b: 'a, T: 'static + Send, MT: MyTrait<'a, 'b, T>> MyTrait<'a, 'b, T> for Box<MT> {}
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT> { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_bound() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return: Clone; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT> { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_dodgy_name() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type r#type; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT> { type r#type = <MT as MyTrait>::r#type; }
                 )
             );
         }

--- a/src/derive/mut.rs
+++ b/src/derive/mut.rs
@@ -38,7 +38,8 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            let attrs   = &t.attrs;
+            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
     }
@@ -225,6 +226,33 @@ mod tests {
                 parse_quote!(
                     #[automatically_derived]
                     impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type r#type = <MT as MyTrait>::r#type; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_attrs() {
+            let trait_ = parse_quote!(
+                trait MyTrait
+                {
+                    #[cfg(target_arch="wasm32")]
+                    type Return;
+                    #[cfg(not(target_arch="wasm32"))]
+                    type Return: Send;                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT
+                    {
+                        #[cfg(target_arch="wasm32")]
+                        type Return = <MT as MyTrait>::Return;
+                        #[cfg(not(target_arch="wasm32"))]
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }

--- a/src/derive/mut.rs
+++ b/src/derive/mut.rs
@@ -38,7 +38,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let attrs   = &t.attrs;
+            let attrs = &t.attrs;
             let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
@@ -185,7 +185,9 @@ mod tests {
         #[test]
         fn associated_types() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return; }
+                trait MyTrait {
+                    type Return;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -193,7 +195,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -201,7 +205,9 @@ mod tests {
         #[test]
         fn associated_types_bound() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return: Clone; }
+                trait MyTrait {
+                    type Return: Clone;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -209,7 +215,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -217,7 +225,9 @@ mod tests {
         #[test]
         fn associated_types_dodgy_name() {
             let trait_ = parse_quote!(
-                trait MyTrait { type r#type; }
+                trait MyTrait {
+                    type r#type;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -225,7 +235,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type r#type = <MT as MyTrait>::r#type; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        type r#type = <MT as MyTrait>::r#type;
+                    }
                 )
             );
         }
@@ -233,12 +245,12 @@ mod tests {
         #[test]
         fn associated_types_attrs() {
             let trait_ = parse_quote!(
-                trait MyTrait
-                {
-                    #[cfg(target_arch="wasm32")]
+                trait MyTrait {
+                    #[cfg(target_arch = "wasm32")]
                     type Return;
-                    #[cfg(not(target_arch="wasm32"))]
-                    type Return: Send;                }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    type Return: Send;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -246,11 +258,10 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT
-                    {
-                        #[cfg(target_arch="wasm32")]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        #[cfg(target_arch = "wasm32")]
                         type Return = <MT as MyTrait>::Return;
-                        #[cfg(not(target_arch="wasm32"))]
+                        #[cfg(not(target_arch = "wasm32"))]
                         type Return = <MT as MyTrait>::Return;
                     }
                 )

--- a/src/derive/mut.rs
+++ b/src/derive/mut.rs
@@ -5,8 +5,13 @@ use crate::utils::{
 };
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
+    // build an identifier for the generic type used for the implementation
+    let trait_ident = &trait_.ident;
+    let generic_type = trait_to_generic_ident(&trait_);
+
     // build the methods
     let mut methods: Vec<syn::ImplItemMethod> = Vec::new();
+    let mut assoc_types: Vec<syn::ImplItemType> = Vec::new();
     for item in trait_.items.iter() {
         if let syn::TraitItem::Method(ref m) = item {
             if let Some(receiver) = m.sig.receiver() {
@@ -30,11 +35,13 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
             let item = parse_quote!(#[inline] #signature { #call });
             methods.push(item)
         }
-    }
 
-    // build an identifier for the generic type used for the implementation
-    let trait_ident = &trait_.ident;
-    let generic_type = trait_to_generic_ident(&trait_);
+        if let syn::TraitItem::Type(t) = item {
+            let t_ident = &t.ident;
+            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            assoc_types.push(item);
+        }
+    }
 
     // build the generics for the impl block:
     // we use the same generics as the trait itself, plus
@@ -55,6 +62,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     Ok(parse_quote!(
         #[automatically_derived]
         impl #impl_generics #trait_ident #trait_generic_names for &mut #generic_type #where_clause {
+            #(#assoc_types)*
             #(#methods)*
         }
     ))
@@ -169,6 +177,54 @@ mod tests {
                         Trait<'a, 'b, T> for &mut T_
                     {
                     }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_bound() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return: Clone; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_dodgy_name() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type r#type; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT { type r#type = <MT as MyTrait>::r#type; }
                 )
             );
         }

--- a/src/derive/rc.rs
+++ b/src/derive/rc.rs
@@ -42,7 +42,8 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            let attrs   = &t.attrs;
+            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
     }
@@ -238,6 +239,33 @@ mod tests {
                 parse_quote!(
                     #[automatically_derived]
                     impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type r#type = <MT as MyTrait>::r#type; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_attrs() {
+            let trait_ = parse_quote!(
+                trait MyTrait
+                {
+                    #[cfg(target_arch="wasm32")]
+                    type Return;
+                    #[cfg(not(target_arch="wasm32"))]
+                    type Return: Send;                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT>
+                    {
+                        #[cfg(target_arch="wasm32")]
+                        type Return = <MT as MyTrait>::Return;
+                        #[cfg(not(target_arch="wasm32"))]
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }

--- a/src/derive/rc.rs
+++ b/src/derive/rc.rs
@@ -42,7 +42,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let attrs   = &t.attrs;
+            let attrs = &t.attrs;
             let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
@@ -198,7 +198,9 @@ mod tests {
         #[test]
         fn associated_types() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return; }
+                trait MyTrait {
+                    type Return;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -206,7 +208,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -214,7 +218,9 @@ mod tests {
         #[test]
         fn associated_types_bound() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return: Clone; }
+                trait MyTrait {
+                    type Return: Clone;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -222,7 +228,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -230,7 +238,9 @@ mod tests {
         #[test]
         fn associated_types_dodgy_name() {
             let trait_ = parse_quote!(
-                trait MyTrait { type r#type; }
+                trait MyTrait {
+                    type r#type;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -238,7 +248,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type r#type = <MT as MyTrait>::r#type; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        type r#type = <MT as MyTrait>::r#type;
+                    }
                 )
             );
         }
@@ -246,12 +258,12 @@ mod tests {
         #[test]
         fn associated_types_attrs() {
             let trait_ = parse_quote!(
-                trait MyTrait
-                {
-                    #[cfg(target_arch="wasm32")]
+                trait MyTrait {
+                    #[cfg(target_arch = "wasm32")]
                     type Return;
-                    #[cfg(not(target_arch="wasm32"))]
-                    type Return: Send;                }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    type Return: Send;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -259,11 +271,10 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT>
-                    {
-                        #[cfg(target_arch="wasm32")]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        #[cfg(target_arch = "wasm32")]
                         type Return = <MT as MyTrait>::Return;
-                        #[cfg(not(target_arch="wasm32"))]
+                        #[cfg(not(target_arch = "wasm32"))]
                         type Return = <MT as MyTrait>::Return;
                     }
                 )

--- a/src/derive/rc.rs
+++ b/src/derive/rc.rs
@@ -5,8 +5,13 @@ use crate::utils::{
 };
 
 pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
+    // build an identifier for the generic type used for the implementation
+    let trait_ident = &trait_.ident;
+    let generic_type = trait_to_generic_ident(&trait_);
+
     // build the methods
     let mut methods: Vec<syn::ImplItemMethod> = Vec::new();
+    let mut assoc_types: Vec<syn::ImplItemType> = Vec::new();
     for item in trait_.items.iter() {
         if let syn::TraitItem::Method(ref m) = item {
             if let Some(receiver) = m.sig.receiver() {
@@ -34,11 +39,13 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
             let item = parse_quote!(#[inline] #signature { #call });
             methods.push(item)
         }
-    }
 
-    // build an identifier for the generic type used for the implementation
-    let trait_ident = &trait_.ident;
-    let generic_type = trait_to_generic_ident(&trait_);
+        if let syn::TraitItem::Type(t) = item {
+            let t_ident = &t.ident;
+            let item = parse_quote!( type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
+            assoc_types.push(item);
+        }
+    }
 
     // build the generics for the impl block:
     // we use the same generics as the trait itself, plus
@@ -59,6 +66,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
     Ok(parse_quote!(
         #[automatically_derived]
         impl #impl_generics #trait_ident #trait_generic_names for std::rc::Rc<#generic_type> #where_clause {
+            #(#assoc_types)*
             #(#methods)*
         }
     ))
@@ -182,6 +190,54 @@ mod tests {
                         MyTrait<'a, 'b, T> for std::rc::Rc<MT>
                     {
                     }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_bound() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type Return: Clone; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type Return = <MT as MyTrait>::Return; }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_types_dodgy_name() {
+            let trait_ = parse_quote!(
+                trait MyTrait { type r#type; }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> { type r#type = <MT as MyTrait>::r#type; }
                 )
             );
         }

--- a/src/derive/ref.rs
+++ b/src/derive/ref.rs
@@ -42,7 +42,7 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
 
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
-            let attrs   = &t.attrs;
+            let attrs = &t.attrs;
             let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident>::#t_ident ; );
             assoc_types.push(item);
         }
@@ -198,7 +198,9 @@ mod tests {
         #[test]
         fn associated_types() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return; }
+                trait MyTrait {
+                    type Return;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -206,7 +208,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &MT { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -214,7 +218,9 @@ mod tests {
         #[test]
         fn associated_types_bound() {
             let trait_ = parse_quote!(
-                trait MyTrait { type Return: Clone; }
+                trait MyTrait {
+                    type Return: Clone;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -222,7 +228,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &MT { type Return = <MT as MyTrait>::Return; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        type Return = <MT as MyTrait>::Return;
+                    }
                 )
             );
         }
@@ -230,7 +238,9 @@ mod tests {
         #[test]
         fn associated_types_dodgy_name() {
             let trait_ = parse_quote!(
-                trait MyTrait { type r#type; }
+                trait MyTrait {
+                    type r#type;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -238,7 +248,9 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &MT { type r#type = <MT as MyTrait>::r#type; }
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        type r#type = <MT as MyTrait>::r#type;
+                    }
                 )
             );
         }
@@ -246,12 +258,12 @@ mod tests {
         #[test]
         fn associated_types_attrs() {
             let trait_ = parse_quote!(
-                trait MyTrait
-                {
-                    #[cfg(target_arch="wasm32")]
+                trait MyTrait {
+                    #[cfg(target_arch = "wasm32")]
                     type Return;
-                    #[cfg(not(target_arch="wasm32"))]
-                    type Return: Send;                }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    type Return: Send;
+                }
             );
             let derived = super::super::derive(&trait_).unwrap();
 
@@ -259,11 +271,10 @@ mod tests {
                 derived,
                 parse_quote!(
                     #[automatically_derived]
-                    impl<MT: MyTrait + ?Sized> MyTrait for &MT
-                    {
-                        #[cfg(target_arch="wasm32")]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        #[cfg(target_arch = "wasm32")]
                         type Return = <MT as MyTrait>::Return;
-                        #[cfg(not(target_arch="wasm32"))]
+                        #[cfg(not(target_arch = "wasm32"))]
                         type Return = <MT as MyTrait>::Return;
                     }
                 )

--- a/tests/derive_arc/successes/assoc_type.rs
+++ b/tests/derive_arc/successes/assoc_type.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Arc))]
+pub trait Counter {
+    type Return: Clone; // <- verify this
+    fn increment(&self) -> Self::Return;
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter for AtomicCounter {
+    // Generate something like `type Return = <A as Assoc>::Return;`.
+    type Return = u8;
+    fn increment(&self) -> u8 {
+        self.count.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter));
+    assert!(impls!(Arc<AtomicCounter>: Counter));
+}

--- a/tests/derive_box/successes/assoc_type.rs
+++ b/tests/derive_box/successes/assoc_type.rs
@@ -1,0 +1,29 @@
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Box))]
+pub trait Counter {
+    type Return: Clone; // <- verify this
+    fn increment(&self) -> Self::Return;
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter for AtomicCounter {
+    // Generate something like `type Return = <A as Assoc>::Return;`.
+    type Return = u8;
+    fn increment(&self) -> u8 {
+        self.count.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter));
+    assert!(impls!(Box<AtomicCounter>: Counter));
+}

--- a/tests/derive_mut/successes/assoc_type.rs
+++ b/tests/derive_mut/successes/assoc_type.rs
@@ -1,0 +1,29 @@
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Mut))]
+pub trait Counter {
+    type Return: Clone; // <- verify this
+    fn increment(&mut self) -> Self::Return;
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter for AtomicCounter {
+    // Generate something like `type Return = <A as Assoc>::Return;`.
+    type Return = u8;
+    fn increment(&mut self) -> u8 {
+        self.count.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:      Counter));
+    assert!(impls!(&mut AtomicCounter: Counter));
+}

--- a/tests/derive_rc/successes/assoc_type.rs
+++ b/tests/derive_rc/successes/assoc_type.rs
@@ -1,0 +1,30 @@
+use std::rc::Rc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Rc))]
+pub trait Counter {
+    type Return: Clone; // <- verify this
+    fn increment(&self) -> Self::Return;
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter for AtomicCounter {
+    // Generate something like `type Return = <A as Assoc>::Return;`.
+    type Return = u8;
+    fn increment(&self) -> u8 {
+        self.count.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:     Counter));
+    assert!(impls!(Rc<AtomicCounter>: Counter));
+}

--- a/tests/derive_ref/successes/assoc_type.rs
+++ b/tests/derive_ref/successes/assoc_type.rs
@@ -1,0 +1,29 @@
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+use blanket::blanket;
+use impls::impls;
+
+#[blanket(derive(Ref))]
+pub trait Counter {
+    type Return: Clone; // <- verify this
+    fn increment(&self) -> Self::Return;
+}
+
+#[derive(Default)]
+struct AtomicCounter {
+    count: AtomicU8,
+}
+
+impl Counter for AtomicCounter {
+    // Generate something like `type Return = <A as Assoc>::Return;`.
+    type Return = u8;
+    fn increment(&self) -> u8 {
+        self.count.fetch_add(1, Ordering::SeqCst)
+    }
+}
+
+fn main() {
+    assert!(impls!(AtomicCounter:  Counter));
+    assert!(impls!(&AtomicCounter: Counter));
+}


### PR DESCRIPTION
This implements the associated types of a trait on the blanket impls. Eg:
```rust
#[blanket(derive(Rc))]
trait MyTrait { type Return; }

// will generate
impl<MT: MyTrait> MyTrait for Rc<MT>
{
   type Return = <MT as MyTrait>::Return;
}
```

As before, this is rebased on top of the other PR's, #3, #4, #5. You might want to merge them first.
