### PR TITLE
Add support for associated type generics

### DIFF
--- a/src/derive/box.rs
+++ b/src/derive/box.rs
@@ -58,7 +58,13 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
             let attrs = &t.attrs;
-            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident #trait_generic_names>::#t_ident ; );
+
+            let t_generics = &t.generics;
+            let where_clause = &t.generics.where_clause;
+            let mut t_generic_names = t_generics.clone();
+            t_generic_names.params = generics_declaration_to_generics(&t_generics.params)?;
+
+            let item = parse_quote!( #(#attrs)* type #t_ident #t_generics = <#generic_type as #trait_ident #trait_generic_names>::#t_ident #t_generic_names #where_clause ; );
             assoc_types.push(item);
         }
     }
@@ -316,6 +322,70 @@ mod tests {
                     #[automatically_derived]
                     impl<T, MT: MyTrait<T>> MyTrait<T> for Box<MT> {
                         type Return = <MT as MyTrait<T>>::Return;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        type Return<T> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_bounded() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T: 'static + Send>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        type Return<T: 'static + Send> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_lifetimes() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<'a>
+                    where
+                        Self: 'a;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait> MyTrait for Box<MT> {
+                        type Return<'a> = <MT as MyTrait>::Return<'a>
+                        where
+                            Self: 'a;
                     }
                 )
             );

--- a/src/derive/mut.rs
+++ b/src/derive/mut.rs
@@ -55,7 +55,13 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
             let attrs = &t.attrs;
-            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident #trait_generic_names>::#t_ident ; );
+
+            let t_generics = &t.generics;
+            let where_clause = &t.generics.where_clause;
+            let mut t_generic_names = t_generics.clone();
+            t_generic_names.params = generics_declaration_to_generics(&t_generics.params)?;
+
+            let item = parse_quote!( #(#attrs)* type #t_ident #t_generics = <#generic_type as #trait_ident #trait_generic_names>::#t_ident #t_generic_names #where_clause ; );
             assoc_types.push(item);
         }
     }
@@ -283,6 +289,70 @@ mod tests {
                     #[automatically_derived]
                     impl<T, MT: MyTrait<T> + ?Sized> MyTrait<T> for &mut MT {
                         type Return = <MT as MyTrait<T>>::Return;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        type Return<T> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_bounded() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T: 'static + Send>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        type Return<T: 'static + Send> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_lifetimes() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<'a>
+                    where
+                        Self: 'a;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &mut MT {
+                        type Return<'a> = <MT as MyTrait>::Return<'a>
+                        where
+                            Self: 'a;
                     }
                 )
             );

--- a/src/derive/rc.rs
+++ b/src/derive/rc.rs
@@ -59,7 +59,13 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
             let attrs = &t.attrs;
-            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident #trait_generic_names>::#t_ident ; );
+
+            let t_generics = &t.generics;
+            let where_clause = &t.generics.where_clause;
+            let mut t_generic_names = t_generics.clone();
+            t_generic_names.params = generics_declaration_to_generics(&t_generics.params)?;
+
+            let item = parse_quote!( #(#attrs)* type #t_ident #t_generics = <#generic_type as #trait_ident #trait_generic_names>::#t_ident #t_generic_names #where_clause ; );
             assoc_types.push(item);
         }
     }
@@ -296,6 +302,70 @@ mod tests {
                     #[automatically_derived]
                     impl<T, MT: MyTrait<T> + ?Sized> MyTrait<T> for std::rc::Rc<MT> {
                         type Return = <MT as MyTrait<T>>::Return;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        type Return<T> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_bounded() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T: 'static + Send>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        type Return<T: 'static + Send> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_lifetimes() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<'a>
+                    where
+                        Self: 'a;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for std::rc::Rc<MT> {
+                        type Return<'a> = <MT as MyTrait>::Return<'a>
+                        where
+                            Self: 'a;
                     }
                 )
             );

--- a/src/derive/ref.rs
+++ b/src/derive/ref.rs
@@ -59,7 +59,13 @@ pub fn derive(trait_: &syn::ItemTrait) -> syn::Result<syn::ItemImpl> {
         if let syn::TraitItem::Type(t) = item {
             let t_ident = &t.ident;
             let attrs = &t.attrs;
-            let item = parse_quote!( #(#attrs)* type #t_ident = <#generic_type as #trait_ident #trait_generic_names>::#t_ident ; );
+
+            let t_generics = &t.generics;
+            let where_clause = &t.generics.where_clause;
+            let mut t_generic_names = t_generics.clone();
+            t_generic_names.params = generics_declaration_to_generics(&t_generics.params)?;
+
+            let item = parse_quote!( #(#attrs)* type #t_ident #t_generics = <#generic_type as #trait_ident #trait_generic_names>::#t_ident #t_generic_names #where_clause ; );
             assoc_types.push(item);
         }
     }
@@ -296,6 +302,70 @@ mod tests {
                     #[automatically_derived]
                     impl<T, MT: MyTrait<T> + ?Sized> MyTrait<T> for &MT {
                         type Return = <MT as MyTrait<T>>::Return;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        type Return<T> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_bounded() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<T: 'static + Send>;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        type Return<T: 'static + Send> = <MT as MyTrait>::Return<T>;
+                    }
+                )
+            );
+        }
+
+        #[test]
+        fn associated_type_generics_lifetimes() {
+            let trait_ = parse_quote!(
+                trait MyTrait {
+                    type Return<'a>
+                    where
+                        Self: 'a;
+                }
+            );
+            let derived = super::super::derive(&trait_).unwrap();
+
+            assert_eq!(
+                derived,
+                parse_quote!(
+                    #[automatically_derived]
+                    impl<MT: MyTrait + ?Sized> MyTrait for &MT {
+                        type Return<'a> = <MT as MyTrait>::Return<'a>
+                        where
+                            Self: 'a;
                     }
                 )
             );


### PR DESCRIPTION
This adds support for the recently stable associated type generics, a.k.a. "generic associated types", <https://blog.rust-lang.org/2022/10/28/gats-stabilization.html>.

Depends on <https://github.com/althonos/blanket/pull/9>.